### PR TITLE
Change the Run command to return the pgxpool we establish

### DIFF
--- a/pgtest_test.go
+++ b/pgtest_test.go
@@ -2,7 +2,6 @@ package pgtest
 
 import (
 	"context"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -12,65 +11,61 @@ const (
 )
 
 func TestPGTest(t *testing.T) {
-	Run(t,
-		func(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
-			// Given
-			_, err := pool.Exec(ctx, `INSERT INTO clinics (id, name, email) VALUES ($1, $2, $3)`, "test-clinic-uuid", "Test Clinic", "test@example.com")
-			require.NoError(t, err)
+	ctx := context.Background()
+	pool := Run(t, ctx, WithDesiredState(dsu))
 
-			// When
-			var name string
-			var email string
-			err = pool.QueryRow(ctx, `SELECT name, email FROM clinics`).Scan(&name, &email)
+	// Given
+	_, err := pool.Exec(ctx, `INSERT INTO clinics (id, name, email) VALUES ($1, $2, $3)`, "test-clinic-uuid", "Test Clinic", "test@example.com")
+	require.NoError(t, err)
 
-			// Then
-			require.NoError(t, err)
-			require.Equal(t, "Test Clinic", name)
-			require.Equal(t, "test@example.com", email)
-		},
-		WithDesiredState(dsu),
-	)
+	// When
+	var name string
+	var email string
+	err = pool.QueryRow(ctx, `SELECT name, email FROM clinics`).Scan(&name, &email)
+
+	// Then
+	require.NoError(t, err)
+	require.Equal(t, "Test Clinic", name)
+	require.Equal(t, "test@example.com", email)
 }
 
 func TestWithReferentialIntegrityEnabled(t *testing.T) {
-	Run(t,
-		func(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
-			_, err := pool.Exec(ctx, `INSERT INTO doctors (id, clinic_id) VALUES ($1, $2)`, "test-doctor-uuid", "non-existent-clinic-uuid")
-			require.Error(t, err)
-		},
-		WithDesiredState(dsu),
-	)
+	ctx := context.Background()
+	pool := Run(t, ctx, WithDesiredState(dsu))
+
+	_, err := pool.Exec(ctx, `INSERT INTO doctors (id, clinic_id) VALUES ($1, $2)`, "test-doctor-uuid", "non-existent-clinic-uuid")
+	require.Error(t, err)
 }
 
 func TestWithReferentialIntegrityDisabled(t *testing.T) {
-	Run(t,
-		func(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
-			_, err := pool.Exec(ctx, `INSERT INTO doctors (id, clinic_id) VALUES ($1, $2)`, "test-doctor-uuid", "non-existent-clinic-uuid")
-			require.NoError(t, err)
-		},
+	ctx := context.Background()
+	pool := Run(t, ctx,
 		WithReferentialIntegrityDisabled(),
 		WithDesiredState(dsu),
 	)
+
+	_, err := pool.Exec(ctx, `INSERT INTO doctors (id, clinic_id) VALUES ($1, $2)`, "test-doctor-uuid", "non-existent-clinic-uuid")
+	require.NoError(t, err)
 }
 
 func TestWithVersion(t *testing.T) {
-	Run(t,
-		func(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
-			// Given
-			_, err := pool.Exec(ctx, `INSERT INTO clinics (id, name, email) VALUES ($1, $2, $3)`, "test-clinic-uuid", "Test Clinic", "test@example.com")
-			require.NoError(t, err)
-
-			// When
-			var name string
-			var email string
-			err = pool.QueryRow(ctx, `SELECT name, email FROM clinics`).Scan(&name, &email)
-
-			// Then
-			require.NoError(t, err)
-			require.Equal(t, "Test Clinic", name)
-			require.Equal(t, "test@example.com", email)
-		},
+	ctx := context.Background()
+	pool := Run(t, ctx,
 		WithVersion("14"),
 		WithDesiredState(dsu),
 	)
+
+	// Given
+	_, err := pool.Exec(ctx, `INSERT INTO clinics (id, name, email) VALUES ($1, $2, $3)`, "test-clinic-uuid", "Test Clinic", "test@example.com")
+	require.NoError(t, err)
+
+	// When
+	var name string
+	var email string
+	err = pool.QueryRow(ctx, `SELECT name, email FROM clinics`).Scan(&name, &email)
+
+	// Then
+	require.NoError(t, err)
+	require.Equal(t, "Test Clinic", name)
+	require.Equal(t, "test@example.com", email)
 }


### PR DESCRIPTION
By swapping the Run command to just returning the pool it reduces the amount of testing in our tests without really losing any clean with the use of t.Cleanup as well as all the normal assertions we have with t.Fatal. I did also pass in a context, this part is optional but its common for me anyway to need a context in the test separate from the tests anyway so one will usually exist either way.

I would normally make an issue but wanted to play around with it locally anyway so might as well see what you think.